### PR TITLE
use stdin and emit RING

### DIFF
--- a/examples/gprs.js
+++ b/examples/gprs.js
@@ -52,7 +52,7 @@ gprs.on('RING', function someoneCalledUs () {
 //  Command the GPRS module via the command line
 process.stdin.resume();
 process.stdin.on('data', function (data) {
-  data = String(data).slice(0, String(data).length-2);  //  Removes the '\n'
+  data = String(data).slice(0, -2);  //  Removes the '\r\n' from the end
   console.log('got command', [data]);
   gprs._txrx(data, 10000, function(err, data) {
     console.log('\nreply:\nerr:\t', err, '\ndata:');


### PR DESCRIPTION
Got rid of the old `process.on('message')` and emission of `'+'` events, emit RING (when someone calls) instead.
