### PR TITLE
Fix postmaster memory leak

### DIFF
--- a/postmaster.js
+++ b/postmaster.js
@@ -261,11 +261,11 @@ Postmaster.prototype.send = function (message, patience, callback, alternate, de
 
     //  If we time out
     var panic = setTimeout(function() {
-      self.forceClear();
       self.removeListener('post', onPost);
       var err = new Error('no reply after ' + patience + ' ms to message "' + message + '"');
       err.type = 'timeout';
       reply(err, []);
+      self.forceClear();
     }, patience);
 
     //  If we get something


### PR DESCRIPTION
Removes post event listener and resets postmaster on timeout.

~~Btw `.once` and `.removeListener` don't work together. I'm not sure if they're supposed to.~~
